### PR TITLE
Skip docker build push for dependabot branches in frontend apps

### DIFF
--- a/.github/workflows/node-build-deploy.yml
+++ b/.github/workflows/node-build-deploy.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Build and publish Docker image
         uses: nais/docker-build-push@v0
         id: docker-build-push
+        if: (!startsWith(github.ref_name, 'dependabot'))
         with:
           team: teamsykefravr
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
Siden alle byggene for dependabot-PRer i frontend feiler på tilgang til Docker push, prøver vi å skippe dette steget i frontendappene. Dette er gjort i backendappene også: https://github.com/navikt/isworkflows/commit/c5eec35ce6569debd3c5cab57cb1f0df4b62d906

Ulempen da er at man ikke får deployet branchen til dev for å teste endringen. Da må man evt branche ut og deploye en versjon til dev selv. Litt tungvindt, men er ikke sikkert alle minor-updates trenger å testes i dev 🤷🏼‍♂️ 

Tenker vi uansett burde være litt "på vakt" etter en dependabot-deploy til prod og sjekke logger/grafana om det oppstår noe støy etterpå, så kan man rulle fort tilbake dersom det var noe galt 🤔 