### PR TITLE
Use built in cache in setup-java / setup-node

### DIFF
--- a/.github/workflows/kotlin-build-deploy.yml
+++ b/.github/workflows/kotlin-build-deploy.yml
@@ -28,27 +28,16 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17.x'
-      - name: Checkout code
-        uses: actions/checkout@v4
+          cache: 'gradle'
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v2
-      - uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
       - name: Run lint
         run: |
           ./gradlew --continue ktlintCheck

--- a/.github/workflows/node-build-deploy.yml
+++ b/.github/workflows/node-build-deploy.yml
@@ -38,15 +38,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-      - name: Cache node modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: 'npm'
       - name: Install deps
         run: |
           npm install --legacy-peer-deps


### PR DESCRIPTION
Pga feilmelding ved bruk av `actions/cache`. Ref tråd: https://nav-it.slack.com/archives/C5KUST8N6/p1728396544275529
Usikker på hvorfor dette har begynt å feile nå, men tror uansett det er en forbedring/forenkling å bruke den innebygde støtten i setup i stedet for egen action.