### PR TITLE
Legg til packages: read permission i node-build-deploy

### DIFF
--- a/.github/workflows/node-build-deploy.yml
+++ b/.github/workflows/node-build-deploy.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      packages: "read"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Endring

Legger til `packages: read` i permissions-blokken for `build-and-publish`-jobben i `node-build-deploy.yml`.

## Hvorfor

Uten denne tilgangen kan ikke `GITHUB_TOKEN` lese npm-pakker fra GitHub Packages (`npm.pkg.github.com`). Dette fører til `403 Forbidden` ved `npm install` for repos som bruker `@navikt`-pakker publisert til GitHub Packages.

Feilen som oppstår:
```
npm error 403 403 Forbidden - Permission installation not allowed to Read organization package
```

## Påvirkning

Alle repos som bruker dette reusable workflowet og har `@navikt`-scoped npm-pakker fra GitHub Packages vil nå kunne installere dem.